### PR TITLE
fix: Fix pagination limitation when deploying to groups

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,35 +37,30 @@ runs:
           echo "ERROR: 'curl' is missing"
           exit 1
         fi
-    - id: get_devices_list
-      shell: bash
-      run: |
-        if [ ! -z ${{ inputs.mender_devices_group }} ]; then
-          MENDER_DEVICES_LIST=$(curl -s \
-            -H "Authorization: Bearer ${{ inputs.mender_pat }}" \
-            ${{ inputs.mender_uri }}/api/management/v1/inventory/groups/${{ inputs.mender_devices_group }}/devices)
-          if [[ ${MENDER_DEVICES_LIST} != \[* ]]; then
-            echo "ERROR: failed to get devices list for group '${{ inputs.mender_devices_group }}', server: ${{ inputs.mender_uri }}"
-            echo "Server's response: ${MENDER_DEVICES_LIST}"
-            exit 1
-          fi
-        else
-          MENDER_DEVICES_LIST=${{ inputs.mender_devices_list }}
-        fi
-        echo "MENDER_DEVICES_LIST=${MENDER_DEVICES_LIST}" >> ${GITHUB_ENV}
     - id: create_deployment
       shell: bash
       run: |
-        # Makes management 'create deployment' API call to Mender server, using curl
-        # https://docs.mender.io/api/#management-api-deployments-create-deployment
-        RESPONSE=$(curl -s -X POST ${{ inputs.mender_uri }}/api/management/v1/deployments/deployments \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/json" \
-          -H "Authorization: Bearer ${{ inputs.mender_pat }}" \
-          --data-raw "{\"name\": \"${{ inputs.mender_deployment_name }}\", \"artifact_name\": \"${{ inputs.mender_release_name }}\", \"devices\": ${MENDER_DEVICES_LIST}}")
+        if [ ! -z ${{ inputs.mender_devices_group }} ]; then
+          # Makes management 'create deployment for group' API call to Mender server, using curl
+          # https://docs.mender.io/api/#management-api-deployments-create-deployment-for-a-group-of-devices
+          RESPONSE=$(curl -s -X POST https://hosted.mender.io/api/management/v1/deployments/deployments/group/${{ inputs.mender_devices_group }} \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -H "Authorization: Bearer ${{ inputs.mender_pat }}" \
+            --data-raw "{\"name\": \"${{ inputs.mender_deployment_name }}\", \"artifact_name\": \"${{ inputs.mender_release_name }}\"}")
+        else
+          # Makes management 'create deployment' API call to Mender server, using curl
+          # https://docs.mender.io/api/#management-api-deployments-create-deployment
+          MENDER_DEVICES_LIST=${{ inputs.mender_devices_list }}
+          RESPONSE=$(curl -s -X POST ${{ inputs.mender_uri }}/api/management/v1/deployments/deployments \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -H "Authorization: Bearer ${{ inputs.mender_pat }}" \
+            --data-raw "{\"name\": \"${{ inputs.mender_deployment_name }}\", \"artifact_name\": \"${{ inputs.mender_release_name }}\", \"devices\": ${MENDER_DEVICES_LIST}}")
+        fi
         if [[ ! -z "${RESPONSE}" || "${RESPONSE}" != "" ]]; then
           echo "ERROR: failed to create deployment '${{ inputs.mender_deployment_name }}', devices: ${MENDER_DEVICES_LIST}, server: ${{ inputs.mender_uri }}"
           echo "Server's response: ${RESPONSE}"
           exit 1
         fi
-        echo "INFO: deployment '${{ inputs.mender_deployment_name }}' with release '${{ inputs.mender_release_name }}' for device group '${MENDER_DEVICES_LIST}' successfully created"
+        echo "INFO: deployment '${{ inputs.mender_deployment_name }}' with release '${{ inputs.mender_release_name }}' for device group '${{ inputs.mender_devices_group }}${{ inputs.mender_devices_list }}' successfully created"


### PR DESCRIPTION
Leverage the API to deploy directly to the given group rather than fetching the devices in the group first to avoid pagination related limitations.